### PR TITLE
docs: Update wrapper references to correct file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ codex --version
 python -m agent_orchestrator run \
   --repo /path/to/your/target/repository \
   --workflow workflow.yaml \
-  --wrapper real_codex_wrapper.py
+  --wrapper codex_wrapper.py
 ```
 
 #### Mock Wrapper (For Testing)
@@ -74,7 +74,7 @@ python -m agent_orchestrator run \
 python -m agent_orchestrator run \
   --repo /path/to/your/target/repository \
   --workflow workflow.yaml \
-  --wrapper src/agent_orchestrator/wrappers/codex_exec_wrapper.py
+  --wrapper mock_wrapper.py
 ```
 
 #### Custom Command Template
@@ -84,6 +84,18 @@ python -m agent_orchestrator run \
   --workflow workflow.yaml \
   --command-template "your-agent-runner --agent {agent} --prompt {prompt} --repo {repo} --output {report}"
 ```
+
+#### Choosing the Right Wrapper
+
+The orchestrator includes several wrapper scripts located in `src/agent_orchestrator/wrappers/`:
+
+- **`claude_wrapper.py`** (Recommended): For Anthropic Claude CLI integration. Provides high-quality code generation and reasoning. Use with `--wrapper-arg --model` and `--wrapper-arg sonnet|opus|haiku` to specify the model.
+
+- **`codex_wrapper.py`**: For OpenAI Codex integration via `codex exec`. Use this if you have access to OpenAI's Codex platform.
+
+- **`mock_wrapper.py`**: For testing and development. Simulates agent execution without calling external APIs.
+
+Choose your wrapper based on which AI platform you have access to and your quality/cost requirements.
 
 ### Step 4: Basic Usage Examples
 
@@ -184,7 +196,7 @@ Enable manual steps that require human input:
 python -m agent_orchestrator run \
   --repo /path/to/your/project \
   --workflow workflow.yaml \
-  --wrapper src/agent_orchestrator/wrappers/codex_exec_wrapper.py \
+  --wrapper codex_wrapper.py \
   --pause-for-human-input
 ```
 
@@ -204,7 +216,7 @@ echo '{"ci.tests": true, "security.scan": true}' > gates.json
 python -m agent_orchestrator run \
   --repo /path/to/your/project \
   --workflow workflow.yaml \
-  --wrapper src/agent_orchestrator/wrappers/codex_exec_wrapper.py \
+  --wrapper codex_wrapper.py \
   --gate-state-file gates.json
 ```
 
@@ -213,7 +225,7 @@ python -m agent_orchestrator run \
 python -m agent_orchestrator run \
   --repo /path/to/your/project \
   --workflow workflow.yaml \
-  --wrapper src/agent_orchestrator/wrappers/codex_exec_wrapper.py \
+  --wrapper codex_wrapper.py \
   --workdir /tmp/agent-workspace \
   --logs-dir /var/log/agents \
   --state-file custom_state.json
@@ -343,7 +355,7 @@ cd path/to/agent_orchestrator
 python -m agent_orchestrator run \
   --repo ../ecommerce-site \
   --workflow workflow_backlog_miner.yaml \
-  --wrapper src/agent_orchestrator/wrappers/codex_exec_wrapper.py \
+  --wrapper codex_wrapper.py \
   --log-level INFO
 ```
 
@@ -357,7 +369,7 @@ cd path/to/agent_orchestrator
 python -m agent_orchestrator run \
   --repo ../your-project \
   --workflow workflow.yaml \
-  --wrapper src/agent_orchestrator/wrappers/codex_exec_wrapper.py \
+  --wrapper codex_wrapper.py \
   --pause-for-human-input \
   --env FEATURE_DESCRIPTION="Add OAuth2 user authentication"
 ```

--- a/sdlc_agents_orchestrator_guide.md
+++ b/sdlc_agents_orchestrator_guide.md
@@ -185,7 +185,7 @@ class StepRuntime:   # dynamic state while running
 - Computes `report_path = <repo>/.agents/run_reports/<run_id>__<step_id>.json`
 - `subprocess.Popen` a wrapper:
   ```bash
-  python scripts/codex_exec_wrapper.py \
+  python src/agent_orchestrator/wrappers/codex_wrapper.py \
     --run-id <run_id> --step-id <step_id> \
     --agent <agent> --prompt <prompt_path> \
     --repo <repo_dir> --report <report_path>
@@ -230,7 +230,7 @@ if all_done or (any_failed and nothing_left):
 
 ## Swap In Your Real `codex exec`
 
-Point the orchestrator at `src/agent_orchestrator/wrappers/codex_exec_wrapper.py` for a production-ready shim.
+Point the orchestrator at `src/agent_orchestrator/wrappers/codex_wrapper.py` for a production-ready shim.
 It shells out to `codex exec`, forwards extra CLI arguments, streams logs, and guarantees a compliant run
 report even when the agent forgets to emit one. Example:
 
@@ -238,7 +238,7 @@ report even when the agent forgets to emit one. Example:
 python -m agent_orchestrator run \
   --repo /path/to/repo \
   --workflow workflows/default.yaml \
-  --wrapper src/agent_orchestrator/wrappers/codex_exec_wrapper.py \
+  --wrapper codex_wrapper.py \
   --wrapper-arg --profile \
   --wrapper-arg prod
 ```
@@ -309,15 +309,15 @@ src/
     gating.py
     state.py
     wrappers/
-      codex_exec_wrapper.py
+      claude_wrapper.py
+      codex_wrapper.py
+      mock_wrapper.py
 README.md
 pyproject.toml
 requirements.txt
 sdlc_agents_poc/
   orchestrator.py
   workflow.yaml
-  scripts/
-    codex_exec_wrapper.py
   schemas/
     run_report.schema.json
   prompts/


### PR DESCRIPTION
## Summary

This PR updates documentation to reference the correct wrapper file names and locations, improving clarity for users.

## Changes

- Update README.md wrapper references:
  - Change `real_codex_wrapper.py` → `codex_wrapper.py`
  - Change `codex_exec_wrapper.py` → `mock_wrapper.py` and `codex_wrapper.py` (context-dependent)
- Add "Choosing the Right Wrapper" section explaining wrapper options (claude_wrapper.py, codex_wrapper.py, mock_wrapper.py)
- Update sdlc_agents_orchestrator_guide.md with correct wrapper paths
- Update file structure documentation to reflect actual wrapper locations in `src/agent_orchestrator/wrappers/`

## Motivation

The documentation referenced wrapper files that don't exist or used inconsistent naming. This PR ensures all documentation matches the actual file structure and provides clear guidance on which wrapper to use.

## Testing

- Documentation review for accuracy
- Verify all referenced file paths exist in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)