### PR TITLE
feat: Add GitHub Issue workflow

### DIFF
--- a/src/agent_orchestrator/cli.py
+++ b/src/agent_orchestrator/cli.py
@@ -134,6 +134,8 @@ def run_from_args(args: argparse.Namespace) -> None:
     state_persister = RunStatePersister(state_file)
 
     base_env = parse_env(args.env)
+    if args.issue_number:
+        base_env["ISSUE_NUMBER"] = args.issue_number
     resolved_logs_dir = Path(args.logs_dir).expanduser().resolve() if args.logs_dir else None
     if args.git_worktree and not resolved_logs_dir:
         resolved_logs_dir = repo_root_for_outputs / ".agents" / "logs"
@@ -238,6 +240,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--env",
         nargs="*",
         help="Environment variables to inject into agent runs (format KEY=VALUE)",
+    )
+    run_parser.add_argument(
+        "--issue-number",
+        help="GitHub issue number to fetch and process (automatically sets ISSUE_NUMBER env var)",
     )
 
     worktree_group = run_parser.add_argument_group("git worktree automation")

--- a/src/agent_orchestrator/prompts/22_github_issue_fetcher.md
+++ b/src/agent_orchestrator/prompts/22_github_issue_fetcher.md
@@ -1,0 +1,49 @@
+# GitHub Issue Fetcher Agent
+
+Goal: Fetch a GitHub issue and save its content for downstream workflow processing.
+
+Input:
+- `ISSUE_NUMBER` environment variable containing the GitHub issue number to fetch
+- Repository context from the current working directory
+
+Task:
+1. Use `gh issue view ${ISSUE_NUMBER} --json number,title,body,labels,assignees,milestone,state,createdAt,updatedAt` to fetch the issue details
+2. Extract and format the issue information into a structured markdown file
+
+Deliverables:
+1. `gh_issue_${ISSUE_NUMBER}.md` at repo root containing:
+   - Issue number and title
+   - Issue state and creation/update timestamps
+   - Labels, assignees, and milestone (if any)
+   - Full issue body/description
+   - Clear section headers for each component
+
+Format the file like this:
+```markdown
+# GitHub Issue #${ISSUE_NUMBER}: ${TITLE}
+
+**State:** ${STATE}
+**Created:** ${CREATED_AT}
+**Updated:** ${UPDATED_AT}
+
+## Labels
+- label1
+- label2
+
+## Assignees
+- @user1
+- @user2
+
+## Milestone
+${MILESTONE_NAME}
+
+## Description
+${BODY}
+```
+
+Completion:
+- Write a run report JSON to `${REPORT_PATH}` with:
+  - `status`: "success" or "failed"
+  - `issue_number`: the issue number fetched
+  - `output_file`: path to the generated markdown file
+  - `issue_title`: the issue title

--- a/src/agent_orchestrator/prompts/23_github_issue_planner.md
+++ b/src/agent_orchestrator/prompts/23_github_issue_planner.md
@@ -1,0 +1,54 @@
+# GitHub Issue Work Planner Agent
+
+Goal: Convert a GitHub issue into a minimal plan and task breakdown for this repo.
+
+Input:
+- Read the GitHub issue file `gh_issue_*.md` at repo root (there should be exactly one)
+- This file contains the full issue details including title, description, labels, and metadata
+
+Task:
+1. Locate and read the `gh_issue_*.md` file in the repo root
+2. Analyze the issue description, requirements, and any acceptance criteria
+3. Break down the work into concrete, actionable tasks
+4. Create a development plan with clear milestones
+
+Deliverables:
+1. `PLAN.md` at repo root containing:
+   - High-level scope and objectives (based on the GitHub issue)
+   - Non-goals (what's explicitly out of scope)
+   - Milestones and success criteria
+   - Reference to the source GitHub issue
+
+2. `tasks.yaml` in `.agents/plan/` listing small tasks with:
+   - Task ID and description
+   - Owner (can be "developer" or specific role)
+   - Acceptance criteria
+   - Dependencies between tasks
+
+3. Update the GitHub issue markdown file to add a note that planning is complete
+
+Format for PLAN.md:
+```markdown
+# Development Plan for Issue #${ISSUE_NUMBER}
+
+**Source:** GitHub Issue #${ISSUE_NUMBER} - ${ISSUE_TITLE}
+
+## Scope
+${HIGH_LEVEL_DESCRIPTION}
+
+## Non-Goals
+- Items explicitly out of scope
+
+## Milestones
+1. Milestone 1
+2. Milestone 2
+
+## Success Criteria
+- Criteria for completion
+```
+
+Completion:
+- Write a run report JSON to `${REPORT_PATH}` referencing produced artifacts:
+  - `status`: "success" or "failed"
+  - `artifacts`: ["PLAN.md", ".agents/plan/tasks.yaml"]
+  - `source_issue`: issue number

--- a/src/agent_orchestrator/workflows/workflow_github_issue.yaml
+++ b/src/agent_orchestrator/workflows/workflow_github_issue.yaml
@@ -1,0 +1,44 @@
+name: github_issue_pipeline
+description: SDLC workflow starting from a GitHub issue through merge
+steps:
+  - id: fetch_github_issue
+    agent: github_issue_fetcher
+    prompt: src/agent_orchestrator/prompts/22_github_issue_fetcher.md
+    needs: []
+    next_on_success: [github_issue_plan]
+
+  - id: github_issue_plan
+    agent: dev_architect
+    prompt: src/agent_orchestrator/prompts/23_github_issue_planner.md
+    needs: [fetch_github_issue]
+    next_on_success: [coding_impl]
+
+  - id: coding_impl
+    agent: coding
+    prompt: src/agent_orchestrator/prompts/02_coding.md
+    needs: [github_issue_plan]
+    next_on_success: [code_review]
+
+  - id: code_review
+    agent: code_review
+    prompt: src/agent_orchestrator/prompts/06_code_review.md
+    needs: [coding_impl]
+    next_on_success: [docs_update]
+
+  - id: docs_update
+    agent: docs_updater
+    prompt: src/agent_orchestrator/prompts/05_docs.md
+    needs: [code_review]
+    next_on_success: [merge_pr]
+
+  - id: merge_pr
+    agent: pr_manager
+    prompt: src/agent_orchestrator/prompts/07_pr_manager.md
+    needs: [docs_update]
+    next_on_success: [cleanup]
+
+  - id: cleanup
+    agent: cleanup
+    prompt: src/agent_orchestrator/prompts/08_cleanup.md
+    needs: [merge_pr]
+    next_on_success: []


### PR DESCRIPTION
## Summary

Add a new workflow that fetches a GitHub issue and processes it through the full SDLC pipeline from planning to merge.

### Components Added

- **Issue Fetcher Prompt** (`22_github_issue_fetcher.md`): Fetches issue details via `gh` CLI and saves to `gh_issue_<number>.md`
- **GitHub Issue Planner Prompt** (`23_github_issue_planner.md`): Specialized planner that reads GitHub issue markdown and creates `PLAN.md` and `tasks.yaml`
- **Workflow** (`workflow_github_issue.yaml`): Full pipeline from issue fetch → plan → code → review → docs → PR → cleanup
- **CLI Flag** (`--issue-number`): Automatically sets `ISSUE_NUMBER` environment variable for the workflow

### Usage

```bash
agent-orchestrator run \
  --repo /path/to/repo \
  --workflow src/agent_orchestrator/workflows/workflow_github_issue.yaml \
  --wrapper /path/to/wrapper \
  --issue-number 42
```

The workflow will:
1. Fetch GitHub issue #42 and save it to `gh_issue_42.md`
2. Plan the work based on the issue content
3. Implement the solution
4. Review, document, and merge

## Test plan

- [ ] Verify CLI accepts `--issue-number` flag
- [ ] Test workflow with a real GitHub issue
- [ ] Confirm issue fetcher creates properly formatted markdown
- [ ] Verify planner reads issue file and creates PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)