### PR TITLE
feat: Add dependency artifact injection for workflow steps

### DIFF
--- a/src/agent_orchestrator/prompts/13_pr_fixer.md
+++ b/src/agent_orchestrator/prompts/13_pr_fixer.md
@@ -9,7 +9,9 @@ Goal: Fix issues identified in PR review comments and commit changes back to the
 - Consider using a dry-run mode or requiring human approval for critical changes
 
 Tasks:
-1. Read TODO items from `${ARTIFACTS_DIR}/pr_reviews/todos.json`
+1. Read TODO items from the previous step's artifact
+   - First, check if `${DEP_CREATE_TODOS_ARTIFACT_0}` environment variable is set (this contains the path to todos.json from the create_todos step)
+   - If not set, fall back to `${ARTIFACTS_DIR}/pr_reviews/todos.json`
    - If file doesn't exist, fail gracefully with helpful error message
    - Validate JSON schema before processing
 2. For each PR with TODOs:


### PR DESCRIPTION
## Summary
Enable downstream steps to automatically receive artifacts from their dependencies via environment variables, eliminating path resolution issues and making artifact passing explicit and reliable.

## Problem
Previously, when `workflow_pr_review_fix.yaml` ran:
- `create_todos` step wrote artifacts to `.agents/runs/<run_id>/artifacts/pr_reviews/todos.json`
- `fix_pr_issues` step couldn't find the file because it looked in wrong location
- Steps had to guess at artifact paths, leading to failures

## Solution
The orchestrator now automatically collects artifacts from dependency steps and injects them as environment variables:
- `DEP_<STEP_ID>_ARTIFACT_<INDEX>`: Individual artifact paths
- `DEP_<STEP_ID>_ARTIFACTS`: Comma-separated list of all artifacts

## Changes
1. **orchestrator.py**: 
   - Added `_collect_dependency_artifacts()` method
   - Injects dependency artifacts as env vars when launching steps
2. **13_pr_fixer.md**: 
   - Updated to read from `${DEP_CREATE_TODOS_ARTIFACT_0}` 
   - Falls back to `${ARTIFACTS_DIR}/pr_reviews/todos.json` for compatibility

## Test Results
Verified with `workflow_pr_review_fix.yaml`:
- ✅ Created 3 TODOs from PR #40 review comments
- ✅ Fixed all 3 issues using injected artifact path
- ✅ Committed and pushed fixes to PR branch
- ✅ Posted comment on PR

## Benefits
- No more hardcoded paths between workflow steps
- Explicit artifact dependencies via environment
- Automatic path resolution (relative → absolute)
- Makes workflows more robust and maintainable

🤖 Generated with [Claude Code](https://claude.com/claude-code)