### PR TITLE
fix: Consolidate all artifact directories to .agents/runs/{run_id}/artifacts

### DIFF
--- a/gh_issue_27.md
+++ b/gh_issue_27.md
@@ -1,0 +1,35 @@
+# GitHub Issue #27: Restore or remove the documented `sdlc_agents_poc/` and `demo_repo/` assets so quickstart instructions stop pointing to missing resources (Low Priority)
+
+**State:** OPEN
+**Created:** 2025-10-01T21:37:10Z
+**Updated:** 2025-10-01T21:48:28Z
+
+## Labels
+- documentation
+- priority:low
+- status:ready
+- docs
+- effort:medium
+
+## Assignees
+- None
+
+## Milestone
+None
+
+## Description
+## Tasks
+
+- [ ] Restore or remove the documented `sdlc_agents_poc/` and `demo_repo/` assets so quickstart instructions stop pointing to missing resources.
+  - Priority: Low Priority
+  - Source: Arch Review Gap 1, Arch Review Gap 10
+  - Size: Medium
+  - Backlog Ref: `backlog/TODO.md`:30
+
+## Context
+Generated from `backlog/TODO.md`. Please keep the backlog and this issue in sync.
+
+---
+This issue was created automatically by the todo_issue_syncer agent.
+
+_Planning complete by dev_architect (Run 3a4cdc47). See PLAN.md and .agents/runs/3a4cdc47/artifacts/plan/tasks.yaml for details._

--- a/gh_issue_39.md
+++ b/gh_issue_39.md
@@ -92,3 +92,5 @@ Update the relevant prompts to:
 ---
 
 _Planning complete by dev_architect (Run 4fdaa837). See PLAN.md and .agents/runs/4fdaa837/artifacts/plan/tasks.yaml for details._
+
+_Planning updated by dev_architect (Run 3a4cdc47). See PLAN.md and .agents/runs/3a4cdc47/artifacts/plan/tasks.yaml for details._

--- a/src/agent_orchestrator/prompts/04_manual.md
+++ b/src/agent_orchestrator/prompts/04_manual.md
@@ -2,7 +2,7 @@
 
 Goal:  Test the application how a user would, and log any defects that you find.
 
-View `MANUAL_TEST_PLAN.md` in `.agents/manual/` to understand how you should test the application. Then perform the test.
+View `MANUAL_TEST_PLAN.md` in `.agents/runs/{run_id}/artifacts/` to understand how you should test the application. Then perform the test.
 
 Deliverables:
 - If any defects found, log an entry in the `backlog/DEFECTS.md` file. Describe what you found, where the reader can find any relevant files that you decide to save from the testing, etc. Whatever another developer would need to fix the defect.

--- a/src/agent_orchestrator/prompts/10_backlog_consolidator.md
+++ b/src/agent_orchestrator/prompts/10_backlog_consolidator.md
@@ -5,7 +5,7 @@ Goal: Read the architecture alignment and tech debt reports, then consolidate th
 Input Sources:
 - `backlog/architecture_alignment.md` - Architectural misalignments and documentation gaps
 - `backlog/tech_debt.md` - Technical debt items, code quality issues, and tooling gaps
-- `.agents/review/REVIEW.md` - This contains code review comments that need to be addressed.
+- `.agents/runs/{run_id}/artifacts/REVIEW.md` - This contains code review comments that need to be addressed.
 - `backlog/HUMAN-INPUT.md` - This contains todos given to the workflow from a human, they will often need elaboration to fill out more details.
 
 Deliverables:

--- a/src/agent_orchestrator/prompts/15_ci_history_miner.md
+++ b/src/agent_orchestrator/prompts/15_ci_history_miner.md
@@ -4,13 +4,13 @@ Goal: Mine CI/CD pipeline history to identify intermittent test failures and col
 
 ## Deliverables
 
-- Analysis report in `.agents/flaky_tests/ci_analysis.json` containing:
+- Analysis report in `.agents/runs/{run_id}/artifacts/flaky_tests/ci_analysis.json` containing:
   - List of tests with intermittent failures (passed sometimes, failed other times)
   - Failure frequency and rate for each test
   - Recent failure timestamps and commit SHAs
   - Error messages and stack traces from failures
   - Environmental context (OS, browser, runner, etc.)
-- Summary report in `.agents/flaky_tests/summary.md` with:
+- Summary report in `.agents/runs/{run_id}/artifacts/flaky_tests/summary.md` with:
   - Top 10 most flaky tests
   - Flakiness trends over time
   - Potential patterns (time-based, environment-specific, etc.)
@@ -83,8 +83,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
   "total_test_runs_analyzed": 450,
   "analysis_period_days": 30,
   "artifacts": [
-    ".agents/flaky_tests/ci_analysis.json",
-    ".agents/flaky_tests/summary.md"
+    ".agents/runs/{run_id}/artifacts/flaky_tests/ci_analysis.json",
+    ".agents/runs/{run_id}/artifacts/flaky_tests/summary.md"
   ],
   "notes": "Analyzed GitHub Actions workflow runs for main branch"
 }

--- a/src/agent_orchestrator/prompts/16_flake_analyzer.md
+++ b/src/agent_orchestrator/prompts/16_flake_analyzer.md
@@ -5,16 +5,16 @@ Goal: Analyze identified flaky tests to determine root causes and classify failu
 ## Input
 
 Read the CI analysis report from the previous step:
-- `.agents/flaky_tests/ci_analysis.json` - List of flaky tests with failure data
+- `.agents/runs/{run_id}/artifacts/flaky_tests/ci_analysis.json` - List of flaky tests with failure data
 
 ## Deliverables
 
-- Detailed analysis report in `.agents/flaky_tests/flake_patterns.json` containing:
+- Detailed analysis report in `.agents/runs/{run_id}/artifacts/flaky_tests/flake_patterns.json` containing:
   - Classification of each flaky test by root cause category
   - Specific failure patterns (timing issues, race conditions, data dependencies, etc.)
   - Recommendations for fixes (e.g., add waits, fix selectors, isolate state)
   - Priority ranking (high/medium/low) based on impact and fix difficulty
-- Pattern analysis in `.agents/flaky_tests/patterns.md` with:
+- Pattern analysis in `.agents/runs/{run_id}/artifacts/flaky_tests/patterns.md` with:
   - Common anti-patterns found across tests
   - Shared failure characteristics
   - Suggested refactoring approaches
@@ -94,8 +94,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
   },
   "high_priority_fixes": 4,
   "artifacts": [
-    ".agents/flaky_tests/flake_patterns.json",
-    ".agents/flaky_tests/patterns.md"
+    ".agents/runs/{run_id}/artifacts/flaky_tests/flake_patterns.json",
+    ".agents/runs/{run_id}/artifacts/flaky_tests/patterns.md"
   ],
   "notes": "Identified 3 tests sharing the same race condition pattern"
 }

--- a/src/agent_orchestrator/prompts/17_test_rewriter.md
+++ b/src/agent_orchestrator/prompts/17_test_rewriter.md
@@ -5,18 +5,18 @@ Goal: Rewrite flaky tests based on identified patterns and root causes to elimin
 ## Input
 
 Read analysis from previous steps:
-- `.agents/flaky_tests/flake_patterns.json` - Categorized flaky tests with fix recommendations
-- `.agents/flaky_tests/patterns.md` - Common patterns and anti-patterns
+- `.agents/runs/{run_id}/artifacts/flaky_tests/flake_patterns.json` - Categorized flaky tests with fix recommendations
+- `.agents/runs/{run_id}/artifacts/flaky_tests/patterns.md` - Common patterns and anti-patterns
 
 ## Deliverables
 
 - Rewritten test files with fixes applied
-- Test modification report in `.agents/flaky_tests/rewrites.json` containing:
+- Test modification report in `.agents/runs/{run_id}/artifacts/flaky_tests/rewrites.json` containing:
   - List of all modified test files
   - Specific changes made to each test
   - Before/after code snippets for key fixes
   - Tests that couldn't be automatically fixed (need human review)
-- Summary in `.agents/flaky_tests/rewrite_summary.md` with:
+- Summary in `.agents/runs/{run_id}/artifacts/flaky_tests/rewrite_summary.md` with:
   - Count of tests fixed by category
   - Explanation of common fixes applied
   - Verification steps for human review
@@ -119,8 +119,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
     "tests/integration/api.test.js"
   ],
   "artifacts": [
-    ".agents/flaky_tests/rewrites.json",
-    ".agents/flaky_tests/rewrite_summary.md"
+    ".agents/runs/{run_id}/artifacts/flaky_tests/rewrites.json",
+    ".agents/runs/{run_id}/artifacts/flaky_tests/rewrite_summary.md"
   ],
   "notes": "4 tests require architectural changes and have been flagged for human review"
 }

--- a/src/agent_orchestrator/prompts/18_test_quarantine_manager.md
+++ b/src/agent_orchestrator/prompts/18_test_quarantine_manager.md
@@ -5,8 +5,8 @@ Goal: Quarantine tests that remain flaky after rewriting attempts, preventing th
 ## Input
 
 Read from previous steps:
-- `.agents/flaky_tests/rewrites.json` - Tests that were rewritten and tests flagged for review
-- `.agents/flaky_tests/flake_patterns.json` - Original flakiness analysis
+- `.agents/runs/{run_id}/artifacts/flaky_tests/rewrites.json` - Tests that were rewritten and tests flagged for review
+- `.agents/runs/{run_id}/artifacts/flaky_tests/flake_patterns.json` - Original flakiness analysis
 
 ## Deliverables
 
@@ -14,14 +14,14 @@ Read from previous steps:
   - Mark tests with `.skip()` or `.todo()` in test files
   - OR move tests to separate quarantine suite (e.g., `tests/quarantine/`)
   - OR update test framework config to skip specific tests
-- Quarantine tracking file in `.agents/flaky_tests/quarantine.json` containing:
+- Quarantine tracking file in `.agents/runs/{run_id}/artifacts/flaky_tests/quarantine.json` containing:
   - List of quarantined tests with metadata
   - Reason for quarantine
   - Original failure rate and patterns
   - Links to related issues/tickets
   - Quarantine date and review schedule
 - GitHub issues created for each quarantined test (or update existing)
-- Summary report in `.agents/flaky_tests/quarantine_summary.md`
+- Summary report in `.agents/runs/{run_id}/artifacts/flaky_tests/quarantine_summary.md`
 
 ## Quarantine Criteria
 
@@ -71,7 +71,7 @@ end
 
 For each quarantined test, create/update:
 
-1. **Quarantine record** in `.agents/flaky_tests/quarantine.json`:
+1. **Quarantine record** in `.agents/runs/{run_id}/artifacts/flaky_tests/quarantine.json`:
 ```json
 {
   "test_name": "e2e/checkout.spec.ts > checkout flow > completes payment",
@@ -160,8 +160,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
   "tests_fixed": 11,
   "total_flaky_tests_resolved": 11,
   "artifacts": [
-    ".agents/flaky_tests/quarantine.json",
-    ".agents/flaky_tests/quarantine_summary.md"
+    ".agents/runs/{run_id}/artifacts/flaky_tests/quarantine.json",
+    ".agents/runs/{run_id}/artifacts/flaky_tests/quarantine_summary.md"
   ],
   "notes": "4 tests quarantined pending architectural changes. 11 tests successfully fixed and verified stable.",
   "next_review_date": "2025-11-01"

--- a/src/agent_orchestrator/prompts/19_coverage_analyzer.md
+++ b/src/agent_orchestrator/prompts/19_coverage_analyzer.md
@@ -4,7 +4,7 @@ Goal: Identify files with low test coverage and detect coverage regressions in r
 
 ## Deliverables
 
-- Coverage analysis report in `.agents/coverage_gaps/analysis.json` containing:
+- Coverage analysis report in `.agents/runs/{run_id}/artifacts/coverage_gaps/analysis.json` containing:
   - List of files with coverage below threshold (default: 70%)
   - Coverage metrics per file: line coverage %, branch coverage %, uncovered lines
   - Diff coverage analysis: files with coverage delta < 0 in recent changes
@@ -12,7 +12,7 @@ Goal: Identify files with low test coverage and detect coverage regressions in r
     - Code complexity (cyclomatic complexity)
     - File change frequency (git history)
     - Critical path indicators (main/core modules)
-- Summary report in `.agents/coverage_gaps/summary.md` with:
+- Summary report in `.agents/runs/{run_id}/artifacts/coverage_gaps/summary.md` with:
   - Top 20 files needing coverage improvement
   - Diff coverage violations (recent PRs/commits with negative coverage delta)
   - Suggested test targets with rationale
@@ -147,8 +147,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
   "diff_coverage_violations": 5,
   "top_priority_files": 20,
   "artifacts": [
-    ".agents/coverage_gaps/analysis.json",
-    ".agents/coverage_gaps/summary.md"
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/analysis.json",
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/summary.md"
   ],
   "notes": "Found 5 files with negative diff coverage. Prioritized 20 files for test generation."
 }

--- a/src/agent_orchestrator/prompts/20_test_generator.md
+++ b/src/agent_orchestrator/prompts/20_test_generator.md
@@ -5,17 +5,17 @@ Goal: Generate comprehensive unit tests for files identified by the Coverage Ana
 ## Deliverables
 
 - Generated test files written to appropriate test directories following project conventions
-- Test generation report in `.agents/coverage_gaps/test_generation.json` containing:
+- Test generation report in `.agents/runs/{run_id}/artifacts/coverage_gaps/test_generation.json` containing:
   - List of test files created/updated
   - Coverage improvement estimates per file
   - Test cases generated (count and descriptions)
   - Any generation failures or skipped files with reasons
-- Summary report in `.agents/coverage_gaps/test_summary.md`
+- Summary report in `.agents/runs/{run_id}/artifacts/coverage_gaps/test_summary.md`
 
 ## Input
 
 Read the coverage analysis from the previous step:
-- `.agents/coverage_gaps/analysis.json`: Contains prioritized files and uncovered lines
+- `.agents/runs/{run_id}/artifacts/coverage_gaps/analysis.json`: Contains prioritized files and uncovered lines
 
 Process the top priority files (up to 20) from the analysis.
 
@@ -175,8 +175,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
   "test_cases_generated": 142,
   "estimated_coverage_improvement": 28.5,
   "artifacts": [
-    ".agents/coverage_gaps/test_generation.json",
-    ".agents/coverage_gaps/test_summary.md"
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/test_generation.json",
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/test_summary.md"
   ],
   "notes": "Generated 142 test cases across 18 files. Estimated coverage improvement: +28.5%"
 }

--- a/src/agent_orchestrator/prompts/21_coverage_validator.md
+++ b/src/agent_orchestrator/prompts/21_coverage_validator.md
@@ -4,20 +4,20 @@ Goal: Run generated tests to validate they pass and measure coverage improvement
 
 ## Deliverables
 
-- Test execution report in `.agents/coverage_gaps/validation.json` containing:
+- Test execution report in `.agents/runs/{run_id}/artifacts/coverage_gaps/validation.json` containing:
   - Test execution results (pass/fail counts)
   - Coverage metrics before and after
   - Coverage delta per file and overall
   - Gate validation results (pass/fail)
   - Failed tests with error messages
-- Validation summary in `.agents/coverage_gaps/validation_summary.md`
+- Validation summary in `.agents/runs/{run_id}/artifacts/coverage_gaps/validation_summary.md`
 - **PR creation** if all gates pass
 - **Rollback** if gates fail (remove generated test files and report)
 
 ## Input
 
 Read test generation results from previous step:
-- `.agents/coverage_gaps/test_generation.json`: List of generated test files
+- `.agents/runs/{run_id}/artifacts/coverage_gaps/test_generation.json`: List of generated test files
 
 ## Validation Process
 
@@ -262,8 +262,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
   "pr_created": true,
   "pr_url": "https://github.com/user/repo/pull/123",
   "artifacts": [
-    ".agents/coverage_gaps/validation.json",
-    ".agents/coverage_gaps/validation_summary.md"
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/validation.json",
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/validation_summary.md"
   ],
   "notes": "All quality gates passed. PR created at https://github.com/user/repo/pull/123"
 }
@@ -278,8 +278,8 @@ Write a run report JSON to `${REPORT_PATH}` with:
   "tests_failed": 2,
   "rollback_completed": true,
   "artifacts": [
-    ".agents/coverage_gaps/validation.json",
-    ".agents/coverage_gaps/validation_summary.md"
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/validation.json",
+    ".agents/runs/{run_id}/artifacts/coverage_gaps/validation_summary.md"
   ],
   "notes": "Quality gates failed. 2 tests failed. Rolled back generated test files."
 }

--- a/src/agent_orchestrator/prompts/21_issue_picker.md
+++ b/src/agent_orchestrator/prompts/21_issue_picker.md
@@ -22,7 +22,7 @@ The workflow configuration defines priority labels in order from highest to lowe
 - `gh issue view` - Get full details of selected issue
 
 ## Output Requirements
-Create a JSON artifact: `.agents/issue_selection.json` with:
+Create a JSON artifact: `.agents/runs/{run_id}/artifacts/issue_selection.json` with:
 ```json
 {
   "selected_issue": {
@@ -47,7 +47,7 @@ Create a JSON artifact: `.agents/issue_selection.json` with:
 }
 ```
 
-Also create a markdown summary: `.agents/issue_selection.md` with:
+Also create a markdown summary: `.agents/runs/{run_id}/artifacts/issue_selection.md` with:
 ```markdown
 # Issue Selection Report
 
@@ -80,8 +80,8 @@ This issue will now be worked through the full SDLC pipeline:
 
 ## Error Handling
 If NO issues match the criteria:
-- Create `.agents/issue_selection.json` with `"selected_issue": null`
-- Create `.agents/issue_selection.md` explaining no matching issues found
+- Create `.agents/runs/{run_id}/artifacts/issue_selection.json` with `"selected_issue": null`
+- Create `.agents/runs/{run_id}/artifacts/issue_selection.md` explaining no matching issues found
 - Exit with appropriate message
 
 ## Example Commands

--- a/src/agent_orchestrator/prompts/22_issue_planning.md
+++ b/src/agent_orchestrator/prompts/22_issue_planning.md
@@ -7,7 +7,7 @@ You are a development architect that creates detailed implementation plans for G
 Convert the selected GitHub issue into a minimal plan and task breakdown for this repo.
 
 ## Input Sources
-**Primary Input**: Read `.agents/issue_selection.json` and `.agents/issue_selection.md` created by the issue picker agent.
+**Primary Input**: Read `.agents/runs/{run_id}/artifacts/issue_selection.json` and `.agents/runs/{run_id}/artifacts/issue_selection.md` created by the issue picker agent.
 
 These files contain:
 - Selected issue number, title, and full description
@@ -16,7 +16,7 @@ These files contain:
 - Selection criteria and rationale
 
 ## Task
-1. Read the selected issue details from `.agents/issue_selection.json`
+1. Read the selected issue details from `.agents/runs/{run_id}/artifacts/issue_selection.json`
 2. Analyze the issue requirements and acceptance criteria
 3. Break down the issue into actionable development tasks
 4. Create a detailed implementation plan
@@ -64,7 +64,7 @@ High-level implementation plan including:
 - [Risk 2 and mitigation]
 ```
 
-### 2. `tasks.yaml` in `.agents/plan/`
+### 2. `tasks.yaml` in `.agents/runs/{run_id}/artifacts/plan/`
 Detailed task breakdown with small, actionable items:
 ```yaml
 issue_reference:
@@ -113,7 +113,7 @@ gh issue comment [issue_number] --body "🤖 **Implementation Plan Created**
 
 A detailed implementation plan has been created and development is starting.
 
-See \`PLAN.md\` and \`.agents/plan/tasks.yaml\` for full details.
+See \`PLAN.md\` and \`.agents/runs/{run_id}/artifacts/plan/tasks.yaml\` for full details.
 
 **Milestones:**
 - [Milestone 1]
@@ -121,7 +121,7 @@ See \`PLAN.md\` and \`.agents/plan/tasks.yaml\` for full details.
 - [Milestone 3]"
 ```
 
-### 4. Create `.agents/plan/planning_summary.json`
+### 4. Create `.agents/runs/{run_id}/artifacts/plan/planning_summary.json`
 ```json
 {
   "issue_number": 123,
@@ -167,21 +167,21 @@ See \`PLAN.md\` and \`.agents/plan/tasks.yaml\` for full details.
 ### Read selected issue
 ```bash
 # Read the issue selection JSON
-cat .agents/issue_selection.json | jq .
+cat .agents/runs/{run_id}/artifacts/issue_selection.json | jq .
 
 # Get full issue details from GitHub
-gh issue view $(cat .agents/issue_selection.json | jq -r '.selected_issue.number')
+gh issue view $(cat .agents/runs/{run_id}/artifacts/issue_selection.json | jq -r '.selected_issue.number')
 ```
 
 ### Update issue status
 ```bash
-ISSUE_NUM=$(cat .agents/issue_selection.json | jq -r '.selected_issue.number')
+ISSUE_NUM=$(cat .agents/runs/{run_id}/artifacts/issue_selection.json | jq -r '.selected_issue.number')
 gh issue edit $ISSUE_NUM --add-label "status:in-progress" --remove-label "status:ready"
 gh issue comment $ISSUE_NUM --body "🤖 Implementation plan created. Development starting..."
 ```
 
 ## Success Criteria
-- ✅ Selected issue details successfully read from `.agents/issue_selection.json`
+- ✅ Selected issue details successfully read from `.agents/runs/{run_id}/artifacts/issue_selection.json`
 - ✅ `PLAN.md` created with comprehensive implementation plan
 - ✅ `tasks.yaml` created with detailed, actionable task breakdown
 - ✅ GitHub issue status updated to "in-progress"
@@ -191,7 +191,7 @@ gh issue comment $ISSUE_NUM --body "🤖 Implementation plan created. Developmen
 - ✅ Technical approach clearly documented
 
 ## Important Notes
-- **Issue Context**: ALWAYS read from `.agents/issue_selection.json` - don't pick from TODO.md
+- **Issue Context**: ALWAYS read from `.agents/runs/{run_id}/artifacts/issue_selection.json` - don't pick from TODO.md
 - **GitHub Integration**: Update the issue status so the team knows work has started
 - **Task Granularity**: Break work into small chunks for better tracking and rollback
 - **Acceptance Criteria**: Preserve all requirements from the original GitHub issue

--- a/src/agent_orchestrator/wrappers/claude_wrapper.py
+++ b/src/agent_orchestrator/wrappers/claude_wrapper.py
@@ -69,9 +69,12 @@ def build_claude_command(
     prompt_path = Path(args.prompt)
     if not prompt_path.exists():
         raise FileNotFoundError(f"Prompt file not found: {args.prompt}")
-    
+
     with open(prompt_path, 'r', encoding='utf-8') as f:
         prompt_content = f.read()
+
+    # Replace {run_id} placeholder with actual run_id
+    prompt_content = prompt_content.replace("{run_id}", args.run_id)
     
     # Enhance the prompt with context about the task
     enhanced_prompt = f"""You are an AI agent named "{args.agent}" working on a software development task.

--- a/src/agent_orchestrator/wrappers/codex_wrapper.py
+++ b/src/agent_orchestrator/wrappers/codex_wrapper.py
@@ -64,9 +64,12 @@ def build_codex_command(
     prompt_path = Path(args.prompt)
     if not prompt_path.exists():
         raise FileNotFoundError(f"Prompt file not found: {args.prompt}")
-    
+
     with open(prompt_path, 'r', encoding='utf-8') as f:
         prompt_content = f.read()
+
+    # Replace {run_id} placeholder with actual run_id
+    prompt_content = prompt_content.replace("{run_id}", args.run_id)
     
     # Enhance the prompt with context about the task
     enhanced_prompt = f"""You are an AI agent named "{args.agent}" working on a software development task.


### PR DESCRIPTION
## Summary
- Consolidates all workflow artifacts to a single location: `.agents/runs/{run_id}/artifacts`
- Updates 11 prompt files to reference the new unified artifact directory structure
- Modifies wrappers to replace `{run_id}` placeholder with actual run ID

## Changes
### Prompt Updates
Updated the following prompts to use `.agents/runs/{run_id}/artifacts`:
- `04_manual.md` - Manual testing artifacts
- `10_backlog_consolidator.md` - Code review artifacts
- `15_ci_history_miner.md` - Flaky test CI analysis
- `16_flake_analyzer.md` - Flake pattern analysis
- `17_test_rewriter.md` - Test rewrite reports
- `18_test_quarantine_manager.md` - Quarantine tracking
- `19_coverage_analyzer.md` - Coverage gap analysis
- `20_test_generator.md` - Test generation reports
- `21_coverage_validator.md` - Test validation reports
- `21_issue_picker.md` - Issue selection artifacts
- `22_issue_planning.md` - Planning artifacts

### Code Changes
- **codex_wrapper.py**: Added `{run_id}` placeholder replacement in prompt content
- **claude_wrapper.py**: Added `{run_id}` placeholder replacement in prompt content

## Test plan
- [ ] Verify prompts correctly reference artifact paths with actual run_id values
- [ ] Run a workflow and confirm artifacts are created in `.agents/runs/{run_id}/artifacts`
- [ ] Verify no artifacts are created in old directories (`.agents/reviews`, `.agents/pr`, etc.)
- [ ] Test that dependent steps can read artifacts from the new location

## Benefits
- **Single source of truth**: All run artifacts in one predictable location
- **Easier debugging**: Find all outputs for a specific run in one directory
- **Better isolation**: Each run's artifacts are cleanly separated
- **Simplified cleanup**: Remove all artifacts for a run by deleting one directory

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)