### PR TITLE
Fix loop_back_to scheduling (#58)

### DIFF
--- a/src/agent_orchestrator/models.py
+++ b/src/agent_orchestrator/models.py
@@ -72,6 +72,7 @@ class StepRuntime:
     metrics: Dict[str, object] = field(default_factory=dict)
     logs: List[str] = field(default_factory=list)
     manual_input_path: Optional[Path] = None
+    blocked_by_loop: Optional[str] = None
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -86,6 +87,7 @@ class StepRuntime:
             "metrics": self.metrics,
             "logs": self.logs,
             "manual_input_path": str(self.manual_input_path) if self.manual_input_path else None,
+            "blocked_by_loop": self.blocked_by_loop,
         }
 
 


### PR DESCRIPTION
## Summary
- ensure gated steps wait for their loop_back target to finish before relaunching
- persist loop-back blockers in run state and cover the behaviour with tests
- add fixture prompts plus regression coverage for indirect loop-back flows

## Testing
- .venv/bin/python -m pytest tests/test_loopback.py