### PR TITLE
feat: Add architectural guidance system for prescriptive constraints

### DIFF
--- a/src/agent_orchestrator/guidance.py
+++ b/src/agent_orchestrator/guidance.py
@@ -1,0 +1,235 @@
+"""
+Guidance system for architectural constraints and design documents.
+
+Provides a lightweight way to point agents to relevant guidance documents
+without bloating every prompt with their full contents. Agents read the
+docs on-demand when their task involves the relevant domain.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+@dataclass
+class GuidanceDoc:
+    """A single guidance document with its metadata."""
+
+    path: Path  # Absolute path to the document
+    name: str  # Filename without extension (e.g., "DATABASE")
+    title: str  # Human-readable title from frontmatter or derived from name
+    consult_when: list[str]  # When agents should read this doc
+    description: str  # Brief description of what the doc covers
+
+    @property
+    def relative_path(self) -> str:
+        """Return the path relative to .agents/guidance/."""
+        return self.path.name
+
+
+@dataclass
+class GuidanceContext:
+    """Collected guidance context for injection into agent prompts."""
+
+    docs: list[GuidanceDoc] = field(default_factory=list)
+    guidance_dir: Optional[Path] = None
+
+    def to_prompt_section(self) -> str:
+        """
+        Format guidance as a lightweight lookup table for agent prompts.
+
+        Does NOT include doc contents - just tells agents where to look.
+        """
+        if not self.docs:
+            return ""
+
+        lines = [
+            "## Architectural Guidance",
+            "",
+            "This repository has architectural guidance documents you MUST consult",
+            "before making certain changes. Read the relevant document(s) BEFORE",
+            "implementing changes in that domain.",
+            "",
+            f"**Location**: `{self.guidance_dir}`" if self.guidance_dir else "",
+            "",
+            "| Document | Consult When |",
+            "|----------|--------------|",
+        ]
+
+        for doc in self.docs:
+            # Combine consult_when into a readable string
+            when_text = "; ".join(doc.consult_when) if doc.consult_when else doc.description
+            # Truncate if too long for table
+            if len(when_text) > 80:
+                when_text = when_text[:77] + "..."
+            lines.append(f"| {doc.name}.md | {when_text} |")
+
+        lines.extend([
+            "",
+            "**IMPORTANT**: Before implementing changes in these areas, READ the",
+            "relevant doc first and follow its constraints. Do not deviate without",
+            "explicit user approval.",
+        ])
+
+        return "\n".join(lines)
+
+
+class GuidanceManager:
+    """
+    Manages reading of architectural guidance documents.
+
+    Guidance documents are markdown files with optional YAML frontmatter
+    that specify when agents should consult them.
+
+    Directory structure:
+        .agents/
+        └── guidance/
+            ├── DATABASE.md
+            ├── API.md
+            └── REPO_LAYOUT.md
+
+    Frontmatter format:
+        ---
+        title: Database Design
+        description: Schema design and naming conventions
+        consult_when:
+          - creating or modifying database tables
+          - writing migrations
+          - changing schemas
+        ---
+        # Database Design
+        ...
+    """
+
+    GUIDANCE_DIR = ".agents/guidance"
+
+    def __init__(
+        self,
+        repo_dir: Path,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._repo_dir = repo_dir.resolve()
+        self._guidance_dir = self._repo_dir / self.GUIDANCE_DIR
+        self._log = logger or logging.getLogger(__name__)
+
+    @property
+    def guidance_dir(self) -> Path:
+        """Return the guidance directory path."""
+        return self._guidance_dir
+
+    def exists(self) -> bool:
+        """Check if the guidance directory exists and has documents."""
+        return self._guidance_dir.exists() and any(self._guidance_dir.glob("*.md"))
+
+    def find_guidance_files(self) -> list[Path]:
+        """Find all guidance markdown files in the guidance directory."""
+        if not self._guidance_dir.exists():
+            return []
+
+        files = sorted(self._guidance_dir.glob("*.md"))
+        return files
+
+    def parse_frontmatter(self, content: str) -> tuple[dict, str]:
+        """
+        Parse YAML frontmatter from markdown content.
+
+        Returns (frontmatter_dict, remaining_content).
+        If no frontmatter, returns ({}, original_content).
+        """
+        # Check for frontmatter delimiter
+        if not content.startswith("---"):
+            return {}, content
+
+        # Find closing delimiter
+        end_match = re.search(r"\n---\s*\n", content[3:])
+        if not end_match:
+            return {}, content
+
+        frontmatter_text = content[3 : 3 + end_match.start()]
+        remaining = content[3 + end_match.end() :]
+
+        try:
+            frontmatter = yaml.safe_load(frontmatter_text) or {}
+        except yaml.YAMLError as exc:
+            self._log.warning("Failed to parse frontmatter: %s", exc)
+            return {}, content
+
+        return frontmatter, remaining
+
+    def read_guidance_doc(self, file_path: Path) -> Optional[GuidanceDoc]:
+        """Read and parse a single guidance document."""
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            self._log.warning("Failed to read %s: %s", file_path, exc)
+            return None
+
+        frontmatter, _ = self.parse_frontmatter(content)
+
+        # Extract name from filename
+        name = file_path.stem  # e.g., "DATABASE" from "DATABASE.md"
+
+        # Get title from frontmatter or derive from name
+        title = frontmatter.get("title", name.replace("_", " ").title())
+
+        # Get consult_when rules
+        consult_when = frontmatter.get("consult_when", [])
+        if isinstance(consult_when, str):
+            consult_when = [consult_when]
+
+        # Get description
+        description = frontmatter.get("description", f"Guidance for {title.lower()}")
+
+        return GuidanceDoc(
+            path=file_path,
+            name=name,
+            title=title,
+            consult_when=consult_when,
+            description=description,
+        )
+
+    def read_all_guidance(self) -> GuidanceContext:
+        """
+        Read all guidance documents and return a context for prompt injection.
+        """
+        files = self.find_guidance_files()
+        docs = []
+
+        for file_path in files:
+            doc = self.read_guidance_doc(file_path)
+            if doc:
+                docs.append(doc)
+
+        # Calculate relative path for display
+        try:
+            rel_guidance_dir = self._guidance_dir.relative_to(self._repo_dir)
+        except ValueError:
+            rel_guidance_dir = self._guidance_dir
+
+        return GuidanceContext(docs=docs, guidance_dir=rel_guidance_dir)
+
+    def get_stats(self) -> dict[str, object]:
+        """Get statistics about guidance documents."""
+        files = self.find_guidance_files()
+        docs_with_frontmatter = 0
+        total_consult_rules = 0
+
+        for f in files:
+            doc = self.read_guidance_doc(f)
+            if doc:
+                if doc.consult_when:
+                    docs_with_frontmatter += 1
+                    total_consult_rules += len(doc.consult_when)
+
+        return {
+            "doc_count": len(files),
+            "docs_with_frontmatter": docs_with_frontmatter,
+            "total_consult_rules": total_consult_rules,
+            "files": [str(f.relative_to(self._repo_dir)) for f in files],
+        }

--- a/src/agent_orchestrator/wrappers/claude_wrapper.py
+++ b/src/agent_orchestrator/wrappers/claude_wrapper.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from agent_orchestrator.memory import MemoryManager
+from agent_orchestrator.guidance import GuidanceManager
 from agent_orchestrator.time_utils import utc_now
 from agent_orchestrator.run_report_format import (
     RUN_REPORT_END,
@@ -121,12 +122,19 @@ def build_claude_command(
     memory_context = memory_manager.read_memories(repo_path)
     memory_section = memory_context.to_prompt_section()
 
+    # Read architectural guidance (if present)
+    guidance_manager = GuidanceManager(repo_dir=repo_path)
+    guidance_context = guidance_manager.read_all_guidance()
+    guidance_section = guidance_context.to_prompt_section()
+
     # Enhance the prompt with context about the task
     enhanced_prompt = f"""You are an AI agent named "{args.agent}" working on a software development task.
 
 Repository: {args.repo}
 Run ID: {args.run_id}
 Step ID: {args.step_id}
+
+{guidance_section}
 
 {memory_section}
 

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -1,0 +1,335 @@
+"""Tests for the guidance system."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agent_orchestrator.guidance import GuidanceManager, GuidanceDoc, GuidanceContext
+
+
+class TestGuidanceManager:
+    """Tests for GuidanceManager class."""
+
+    def test_exists_returns_false_when_no_guidance_dir(self, tmp_path):
+        """Test that exists() returns False when guidance directory doesn't exist."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        assert not manager.exists()
+
+    def test_exists_returns_false_when_dir_empty(self, tmp_path):
+        """Test that exists() returns False when guidance directory has no .md files."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+        manager = GuidanceManager(repo_dir=tmp_path)
+        assert not manager.exists()
+
+    def test_exists_returns_true_when_has_docs(self, tmp_path):
+        """Test that exists() returns True when guidance directory has .md files."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+        (guidance_dir / "TEST.md").write_text("# Test")
+
+        manager = GuidanceManager(repo_dir=tmp_path)
+        assert manager.exists()
+
+    def test_find_guidance_files_empty_when_no_dir(self, tmp_path):
+        """Test that find_guidance_files returns empty list when no guidance dir."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        assert manager.find_guidance_files() == []
+
+    def test_find_guidance_files_returns_sorted(self, tmp_path):
+        """Test that find_guidance_files returns files sorted alphabetically."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+        (guidance_dir / "ZEBRA.md").write_text("# Zebra")
+        (guidance_dir / "API.md").write_text("# API")
+        (guidance_dir / "DATABASE.md").write_text("# Database")
+
+        manager = GuidanceManager(repo_dir=tmp_path)
+        files = manager.find_guidance_files()
+
+        assert len(files) == 3
+        assert files[0].name == "API.md"
+        assert files[1].name == "DATABASE.md"
+        assert files[2].name == "ZEBRA.md"
+
+
+class TestFrontmatterParsing:
+    """Tests for YAML frontmatter parsing."""
+
+    def test_parse_frontmatter_no_frontmatter(self, tmp_path):
+        """Test parsing content without frontmatter."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        content = "# Just a heading\n\nSome content."
+
+        fm, remaining = manager.parse_frontmatter(content)
+
+        assert fm == {}
+        assert remaining == content
+
+    def test_parse_frontmatter_with_valid_frontmatter(self, tmp_path):
+        """Test parsing content with valid YAML frontmatter."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        content = """---
+title: Test Document
+description: A test description
+consult_when:
+  - doing thing A
+  - doing thing B
+---
+# Heading
+
+Content here.
+"""
+        fm, remaining = manager.parse_frontmatter(content)
+
+        assert fm["title"] == "Test Document"
+        assert fm["description"] == "A test description"
+        assert fm["consult_when"] == ["doing thing A", "doing thing B"]
+        assert remaining.strip().startswith("# Heading")
+
+    def test_parse_frontmatter_missing_closing(self, tmp_path):
+        """Test parsing content with missing closing delimiter."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        content = """---
+title: Broken
+# This has no closing ---
+"""
+        fm, remaining = manager.parse_frontmatter(content)
+
+        assert fm == {}
+        assert remaining == content
+
+    def test_parse_frontmatter_invalid_yaml(self, tmp_path):
+        """Test parsing content with invalid YAML."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        content = """---
+title: [invalid: yaml: here
+---
+# Content
+"""
+        fm, remaining = manager.parse_frontmatter(content)
+
+        # Should return empty dict and original content on parse error
+        assert fm == {}
+        assert remaining == content
+
+
+class TestReadGuidanceDoc:
+    """Tests for reading individual guidance documents."""
+
+    def test_read_guidance_doc_with_frontmatter(self, tmp_path):
+        """Test reading a guidance doc with frontmatter."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+
+        doc_content = """---
+title: Database Design
+description: How to design database schemas
+consult_when:
+  - creating tables
+  - writing migrations
+---
+# Database Design
+
+Always use snake_case.
+"""
+        doc_path = guidance_dir / "DATABASE.md"
+        doc_path.write_text(doc_content)
+
+        manager = GuidanceManager(repo_dir=tmp_path)
+        doc = manager.read_guidance_doc(doc_path)
+
+        assert doc is not None
+        assert doc.name == "DATABASE"
+        assert doc.title == "Database Design"
+        assert doc.description == "How to design database schemas"
+        assert doc.consult_when == ["creating tables", "writing migrations"]
+
+    def test_read_guidance_doc_without_frontmatter(self, tmp_path):
+        """Test reading a guidance doc without frontmatter uses defaults."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+
+        doc_content = """# API Design
+
+Use RESTful patterns.
+"""
+        doc_path = guidance_dir / "API_DESIGN.md"
+        doc_path.write_text(doc_content)
+
+        manager = GuidanceManager(repo_dir=tmp_path)
+        doc = manager.read_guidance_doc(doc_path)
+
+        assert doc is not None
+        assert doc.name == "API_DESIGN"
+        assert doc.title == "Api Design"  # Title case from filename
+        assert doc.consult_when == []
+        assert "Api Design" in doc.description.lower() or "api design" in doc.description.lower()
+
+    def test_read_guidance_doc_missing_file(self, tmp_path):
+        """Test reading a non-existent file returns None."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        doc = manager.read_guidance_doc(tmp_path / "NONEXISTENT.md")
+
+        assert doc is None
+
+    def test_read_guidance_doc_consult_when_as_string(self, tmp_path):
+        """Test that consult_when as string is converted to list."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+
+        doc_content = """---
+consult_when: just a string
+---
+# Content
+"""
+        doc_path = guidance_dir / "TEST.md"
+        doc_path.write_text(doc_content)
+
+        manager = GuidanceManager(repo_dir=tmp_path)
+        doc = manager.read_guidance_doc(doc_path)
+
+        assert doc.consult_when == ["just a string"]
+
+
+class TestGuidanceContext:
+    """Tests for GuidanceContext and prompt generation."""
+
+    def test_empty_context_produces_empty_string(self):
+        """Test that empty context produces no prompt section."""
+        context = GuidanceContext(docs=[], guidance_dir=None)
+        assert context.to_prompt_section() == ""
+
+    def test_context_produces_table(self, tmp_path):
+        """Test that context with docs produces a markdown table."""
+        docs = [
+            GuidanceDoc(
+                path=tmp_path / "DATABASE.md",
+                name="DATABASE",
+                title="Database Design",
+                consult_when=["creating tables", "writing migrations"],
+                description="Schema design guide",
+            ),
+            GuidanceDoc(
+                path=tmp_path / "API.md",
+                name="API",
+                title="API Design",
+                consult_when=["adding endpoints"],
+                description="API patterns",
+            ),
+        ]
+        context = GuidanceContext(docs=docs, guidance_dir=Path(".agents/guidance"))
+
+        section = context.to_prompt_section()
+
+        assert "## Architectural Guidance" in section
+        assert "| Document | Consult When |" in section
+        assert "DATABASE.md" in section
+        assert "API.md" in section
+        assert "creating tables" in section
+        assert "writing migrations" in section
+        assert ".agents/guidance" in section
+
+    def test_context_truncates_long_consult_when(self, tmp_path):
+        """Test that very long consult_when entries are truncated."""
+        long_text = "x" * 100
+        docs = [
+            GuidanceDoc(
+                path=tmp_path / "TEST.md",
+                name="TEST",
+                title="Test",
+                consult_when=[long_text],
+                description="Test doc",
+            ),
+        ]
+        context = GuidanceContext(docs=docs, guidance_dir=Path(".agents/guidance"))
+
+        section = context.to_prompt_section()
+
+        # Should be truncated with ...
+        assert "..." in section
+        assert long_text not in section  # Full text should not appear
+
+
+class TestReadAllGuidance:
+    """Integration tests for reading all guidance."""
+
+    def test_read_all_guidance_empty_repo(self, tmp_path):
+        """Test reading guidance from repo with no guidance dir."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        context = manager.read_all_guidance()
+
+        assert context.docs == []
+        assert context.to_prompt_section() == ""
+
+    def test_read_all_guidance_multiple_docs(self, tmp_path):
+        """Test reading multiple guidance documents."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+
+        (guidance_dir / "DATABASE.md").write_text("""---
+title: Database Design
+consult_when:
+  - creating tables
+---
+# Database
+""")
+        (guidance_dir / "API.md").write_text("""---
+title: API Design
+consult_when:
+  - adding endpoints
+---
+# API
+""")
+
+        manager = GuidanceManager(repo_dir=tmp_path)
+        context = manager.read_all_guidance()
+
+        assert len(context.docs) == 2
+        names = [d.name for d in context.docs]
+        assert "DATABASE" in names
+        assert "API" in names
+
+
+class TestGetStats:
+    """Tests for guidance statistics."""
+
+    def test_get_stats_empty_repo(self, tmp_path):
+        """Test stats for repo with no guidance."""
+        manager = GuidanceManager(repo_dir=tmp_path)
+        stats = manager.get_stats()
+
+        assert stats["doc_count"] == 0
+        assert stats["docs_with_frontmatter"] == 0
+        assert stats["total_consult_rules"] == 0
+        assert stats["files"] == []
+
+    def test_get_stats_with_docs(self, tmp_path):
+        """Test stats for repo with guidance docs."""
+        guidance_dir = tmp_path / ".agents" / "guidance"
+        guidance_dir.mkdir(parents=True)
+
+        (guidance_dir / "DATABASE.md").write_text("""---
+consult_when:
+  - rule1
+  - rule2
+  - rule3
+---
+# DB
+""")
+        (guidance_dir / "API.md").write_text("""---
+consult_when:
+  - rule4
+---
+# API
+""")
+        (guidance_dir / "PLAIN.md").write_text("# No frontmatter")
+
+        manager = GuidanceManager(repo_dir=tmp_path)
+        stats = manager.get_stats()
+
+        assert stats["doc_count"] == 3
+        assert stats["docs_with_frontmatter"] == 2
+        assert stats["total_consult_rules"] == 4
+        assert len(stats["files"]) == 3


### PR DESCRIPTION
## Summary

Adds a lightweight guidance system that points agents to architectural documents without bloating prompts. Designed for large enterprise projects where agents must follow prescriptive constraints (database design, API patterns, repo layout, etc.).

- Agents see a compact lookup table pointing to `.agents/guidance/*.md` files
- Each doc uses YAML frontmatter with `consult_when` rules to specify when agents should read it
- Agents read full docs on-demand when their task matches a rule
- Complements existing AGENTS.md memory system (gotchas vs constraints)

## Changes

- `src/agent_orchestrator/guidance.py` - GuidanceManager class with frontmatter parsing
- `src/agent_orchestrator/wrappers/claude_wrapper.py` - Inject guidance lookup table into prompts
- `tests/test_guidance.py` - 20 comprehensive tests
- `README.md` - Step 6.5: Architectural Guidance Documents

## How It Works

Create guidance docs in target repo:
```bash
mkdir -p .agents/guidance
cat > .agents/guidance/DATABASE.md << 'EOF'
---
title: Database Design
consult_when:
  - creating or modifying database tables
  - writing migrations
---
# Database Design Guide
...
EOF
```

Agents see a lookup table:
```
| Document     | Consult When                                      |
|--------------|---------------------------------------------------|
| DATABASE.md  | creating or modifying tables; writing migrations  |
```

## Test plan

- [x] Run `pytest tests/test_guidance.py` - 20 tests passing
- [ ] Manual test: Create guidance doc in target repo and verify lookup table appears in agent prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
