### PR TITLE
feat: Add JSON Schema for run reports (closes #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **JSON Schema for run reports** (Issue #16)
+  - Added `schemas/run_report.schema.json` defining the formal structure of run reports
+  - Schema uses JSON Schema draft 2020-12 and validates all required and optional fields
+  - Includes `MemoryUpdate` definition for memory_updates array items
+  - Documents optional validation flow in `sdlc_agents_orchestrator_guide.md`
+  - Schema is optional for orchestrator runtime but useful for CI pipelines and custom tooling
+
 - **Loop control structure for iterating over collections in workflows** (Issue #63)
   - Added `LoopConfig` model to define loop behavior with multiple item sources
   - Added `loop` field to Step model for configuring iteration over collections

--- a/schemas/run_report.schema.json
+++ b/schemas/run_report.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/anthropics/agent-orchestrator/schemas/run_report.schema.json",
+  "title": "Run Report",
+  "description": "Schema for run reports emitted by SDLC agents. Each agent step writes a run report JSON file to signal completion to the orchestrator.",
+  "type": "object",
+  "required": [
+    "schema",
+    "run_id",
+    "step_id",
+    "agent",
+    "status",
+    "started_at",
+    "ended_at"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "run_report@v0",
+      "description": "Schema version identifier. Must be 'run_report@v0' for this schema version."
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for the orchestrator run. Used to correlate all steps in a single workflow execution."
+    },
+    "step_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier for the workflow step. Matches the 'id' field in the workflow YAML definition."
+    },
+    "agent": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name of the agent that executed this step (e.g., 'coding', 'work_planner', 'code_review')."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["COMPLETED", "FAILED"],
+      "description": "Completion status of the step. 'COMPLETED' indicates success; 'FAILED' indicates the step could not complete successfully."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the step started execution. Must be timezone-aware (e.g., '2025-09-30T12:00:00Z')."
+    },
+    "ended_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the step finished execution. Must be timezone-aware (e.g., '2025-09-30T12:05:42Z')."
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": [],
+      "description": "List of file paths to artifacts produced by this step. Paths should be relative to the repository root."
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {},
+      "description": "Key-value pairs of metrics collected during step execution (e.g., tokens_in, tokens_out, duration_ms)."
+    },
+    "logs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": [],
+      "description": "List of log messages describing actions taken during the step. Must contain concrete summaries, not placeholder text."
+    },
+    "next_suggested_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "Optional suggestions for follow-up steps or actions. Informational only; does not affect workflow execution."
+    },
+    "gate_failure": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, triggers the loop_back_to target if configured on the step. Used for quality gate failures that require rework."
+    },
+    "memory_updates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/MemoryUpdate"
+      },
+      "default": [],
+      "description": "List of memory updates to persist in AGENTS.md files. Used to record learned knowledge for future agent runs."
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "MemoryUpdate": {
+      "type": "object",
+      "required": ["scope", "section", "entry"],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Relative path to target directory for the AGENTS.md file (e.g., 'src/api' or '.' for root)."
+        },
+        "section": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Section name in the AGENTS.md file (e.g., 'Gotchas', 'Patterns')."
+        },
+        "entry": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The content to add to the specified section."
+        }
+      },
+      "additionalProperties": false,
+      "description": "A single memory update to be written to an AGENTS.md file."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `schemas/run_report.schema.json` defining the formal structure of run reports emitted by SDLC agents
- Uses JSON Schema draft 2020-12 with full field definitions and `MemoryUpdate` sub-schema
- Documents optional validation flow in `sdlc_agents_orchestrator_guide.md` for CI pipelines and custom tooling

Closes #16

## Changes

| File | Description |
|------|-------------|
| `schemas/run_report.schema.json` | New JSON Schema with all required/optional fields |
| `sdlc_agents_orchestrator_guide.md` | Added optional validation flow section and updated directory tree |
| `CHANGELOG.md` | Documented feature addition |

## Test plan

- [x] Verify schema validates existing run report examples
- [x] Ensure existing tests pass (schema is optional, no runtime validation required)
- [x] Confirm documentation is clear and provides working example

🤖 Generated with [Claude Code](https://claude.com/claude-code)