### PR TITLE
feat: Add SQLite archive for run metadata to preserve history after cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,10 +553,42 @@ python -m agent_orchestrator.cli run \
   --skip-cleanup
 ```
 
+**Run Archive for Historical Tracking:**
+
+When runs are cleaned up, their metadata is automatically preserved in a lightweight SQLite database at `.agents/run_archive.db`. This allows you to:
+- Track all-time costs and token usage across all runs (including deleted ones)
+- View historical run data in the web dashboard
+- Query archived runs via the API
+
+The archive database is created automatically on first use - no setup required. Each archived run stores:
+- Run ID, workflow name, and status
+- Total cost, input/output tokens
+- Steps completed/failed counts
+- Work summary (which steps ran)
+- Timestamps (created, ended, archived)
+
+View archived runs in the web dashboard:
+- **Dashboard**: Shows "All-Time Totals (Archived Runs)" section
+- **Run Explorer**: Filter by source (All / Live / Archived)
+- **Run Detail**: View archived run metadata (step details not preserved)
+
+API endpoints for archived data:
+```bash
+# Get archive statistics
+curl http://localhost:8080/api/archive/stats
+
+# Get all archived runs
+curl http://localhost:8080/api/archive/runs
+
+# Get runs with source filter
+curl "http://localhost:8080/api/runs?source=archived"
+```
+
 **Best practices:**
 - Failed runs are preserved by default for post-mortem analysis - review them promptly before count-based cleanup removes them
 - Use `--skip-cleanup` when investigating issues across multiple runs
 - The cleanup settings (48 hours, 10 runs) are currently hardcoded; adjust the source if your workflow needs different retention
+- The archive database grows slowly (one row per run) - no maintenance needed
 
 ### Step 6: Customizing Agent Behavior with Prompt Overrides
 
@@ -1330,6 +1362,7 @@ steps:
   - `state.py` — Execution state persistence
   - `reporting.py` — Run report validation and parsing
   - `run_cleanup.py` — Automatic run directory cleanup with time and count-based retention
+  - `run_archive.py` — SQLite-based archive for preserving run metadata after cleanup
   - `time_utils.py` — Timezone-aware timestamp helpers shared across the orchestrator
   - `gating.py` — Conditional workflow progression
   - `memory.py` — Persistent agent memory via AGENTS.md files

--- a/src/agent_orchestrator/run_archive.py
+++ b/src/agent_orchestrator/run_archive.py
@@ -1,0 +1,413 @@
+"""
+Run archive database for preserving metadata of cleaned-up runs.
+
+Stores run summaries in a lightweight SQLite database at .agents/run_archive.db
+so historical run data survives retention cleanup.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .time_utils import utc_now
+
+_LOG = logging.getLogger(__name__)
+
+# Database schema version for future migrations
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class ArchivedRun:
+    """Represents an archived run's metadata."""
+
+    run_id: str
+    workflow_name: str
+    status: str
+    created_at: str
+    ended_at: Optional[str]
+    total_cost_usd: float
+    total_input_tokens: int
+    total_output_tokens: int
+    steps_completed: int
+    steps_failed: int
+    work_summary: str
+    archived_at: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "workflow_name": self.workflow_name,
+            "status": self.status,
+            "created_at": self.created_at,
+            "ended_at": self.ended_at,
+            "total_cost_usd": self.total_cost_usd,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "steps_completed": self.steps_completed,
+            "steps_failed": self.steps_failed,
+            "work_summary": self.work_summary,
+            "archived_at": self.archived_at,
+        }
+
+
+class RunArchive:
+    """
+    SQLite-based archive for run metadata.
+
+    Stores run summaries that survive cleanup, allowing historical
+    tracking of costs, runs, and work completed.
+    """
+
+    def __init__(self, repo_dir: Path, logger: Optional[logging.Logger] = None):
+        self._repo_dir = repo_dir
+        self._db_path = repo_dir / ".agents" / "run_archive.db"
+        self._log = logger or logging.getLogger(__name__)
+        self._ensure_db()
+
+    def _ensure_db(self) -> None:
+        """Create the database and tables if they don't exist."""
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with sqlite3.connect(self._db_path) as conn:
+            cursor = conn.cursor()
+
+            # Create schema version table
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY
+                )
+            """)
+
+            # Check current version
+            cursor.execute("SELECT version FROM schema_version LIMIT 1")
+            row = cursor.fetchone()
+            current_version = row[0] if row else 0
+
+            if current_version < SCHEMA_VERSION:
+                self._migrate(conn, current_version)
+
+    def _migrate(self, conn: sqlite3.Connection, from_version: int) -> None:
+        """Run database migrations."""
+        cursor = conn.cursor()
+
+        if from_version < 1:
+            # Initial schema
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS archived_runs (
+                    run_id TEXT PRIMARY KEY,
+                    workflow_name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    ended_at TEXT,
+                    total_cost_usd REAL DEFAULT 0.0,
+                    total_input_tokens INTEGER DEFAULT 0,
+                    total_output_tokens INTEGER DEFAULT 0,
+                    steps_completed INTEGER DEFAULT 0,
+                    steps_failed INTEGER DEFAULT 0,
+                    work_summary TEXT DEFAULT '',
+                    archived_at TEXT NOT NULL
+                )
+            """)
+
+            # Index for common queries
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_archived_runs_created
+                ON archived_runs(created_at DESC)
+            """)
+
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_archived_runs_workflow
+                ON archived_runs(workflow_name)
+            """)
+
+            # Update schema version
+            cursor.execute("DELETE FROM schema_version")
+            cursor.execute("INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,))
+
+            conn.commit()
+            self._log.info("Initialized run archive database (schema v%d)", SCHEMA_VERSION)
+
+    def archive_run(
+        self,
+        run_id: str,
+        workflow_name: str,
+        status: str,
+        created_at: str,
+        ended_at: Optional[str] = None,
+        total_cost_usd: float = 0.0,
+        total_input_tokens: int = 0,
+        total_output_tokens: int = 0,
+        steps_completed: int = 0,
+        steps_failed: int = 0,
+        work_summary: str = "",
+    ) -> bool:
+        """
+        Archive a run's metadata.
+
+        Returns True if the run was archived, False if it already exists.
+        """
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    INSERT OR IGNORE INTO archived_runs (
+                        run_id, workflow_name, status, created_at, ended_at,
+                        total_cost_usd, total_input_tokens, total_output_tokens,
+                        steps_completed, steps_failed, work_summary, archived_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run_id,
+                        workflow_name,
+                        status,
+                        created_at,
+                        ended_at,
+                        total_cost_usd,
+                        total_input_tokens,
+                        total_output_tokens,
+                        steps_completed,
+                        steps_failed,
+                        work_summary,
+                        utc_now(),
+                    ),
+                )
+                conn.commit()
+
+                if cursor.rowcount > 0:
+                    self._log.info(
+                        "Archived run %s: %s [%s] $%.4f",
+                        run_id,
+                        workflow_name,
+                        status,
+                        total_cost_usd,
+                    )
+                    return True
+                return False
+
+        except sqlite3.Error as e:
+            self._log.error("Failed to archive run %s: %s", run_id, e)
+            return False
+
+    def get_archived_run(self, run_id: str) -> Optional[ArchivedRun]:
+        """Get a single archived run by ID."""
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.cursor()
+                cursor.execute("SELECT * FROM archived_runs WHERE run_id = ?", (run_id,))
+                row = cursor.fetchone()
+                if row:
+                    return ArchivedRun(**dict(row))
+                return None
+        except sqlite3.Error as e:
+            self._log.error("Failed to get archived run %s: %s", run_id, e)
+            return None
+
+    def get_all_archived_runs(
+        self,
+        limit: Optional[int] = None,
+        offset: int = 0,
+        workflow_name: Optional[str] = None,
+    ) -> List[ArchivedRun]:
+        """
+        Get archived runs with optional filtering.
+
+        Args:
+            limit: Maximum number of runs to return
+            offset: Number of runs to skip (for pagination)
+            workflow_name: Filter by workflow name
+        """
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.cursor()
+
+                query = "SELECT * FROM archived_runs"
+                params: List[Any] = []
+
+                if workflow_name:
+                    query += " WHERE workflow_name = ?"
+                    params.append(workflow_name)
+
+                query += " ORDER BY created_at DESC"
+
+                if limit:
+                    query += " LIMIT ?"
+                    params.append(limit)
+                    if offset:
+                        query += " OFFSET ?"
+                        params.append(offset)
+
+                cursor.execute(query, params)
+                return [ArchivedRun(**dict(row)) for row in cursor.fetchall()]
+
+        except sqlite3.Error as e:
+            self._log.error("Failed to get archived runs: %s", e)
+            return []
+
+    def get_archive_stats(self) -> Dict[str, Any]:
+        """Get aggregate statistics from the archive."""
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                cursor = conn.cursor()
+
+                cursor.execute("""
+                    SELECT
+                        COUNT(*) as total_runs,
+                        SUM(CASE WHEN status = 'COMPLETED' THEN 1 ELSE 0 END) as completed_runs,
+                        SUM(CASE WHEN status = 'FAILED' THEN 1 ELSE 0 END) as failed_runs,
+                        SUM(total_cost_usd) as total_cost_usd,
+                        SUM(total_input_tokens) as total_input_tokens,
+                        SUM(total_output_tokens) as total_output_tokens,
+                        SUM(steps_completed) as total_steps_completed,
+                        SUM(steps_failed) as total_steps_failed
+                    FROM archived_runs
+                """)
+                row = cursor.fetchone()
+
+                return {
+                    "total_runs": row[0] or 0,
+                    "completed_runs": row[1] or 0,
+                    "failed_runs": row[2] or 0,
+                    "total_cost_usd": row[3] or 0.0,
+                    "total_input_tokens": row[4] or 0,
+                    "total_output_tokens": row[5] or 0,
+                    "total_steps_completed": row[6] or 0,
+                    "total_steps_failed": row[7] or 0,
+                }
+
+        except sqlite3.Error as e:
+            self._log.error("Failed to get archive stats: %s", e)
+            return {
+                "total_runs": 0,
+                "completed_runs": 0,
+                "failed_runs": 0,
+                "total_cost_usd": 0.0,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_steps_completed": 0,
+                "total_steps_failed": 0,
+            }
+
+    def is_archived(self, run_id: str) -> bool:
+        """Check if a run is already archived."""
+        try:
+            with sqlite3.connect(self._db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1 FROM archived_runs WHERE run_id = ?", (run_id,))
+                return cursor.fetchone() is not None
+        except sqlite3.Error:
+            return False
+
+
+def extract_run_metadata(run_dir: Path, daily_stats_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """
+    Extract metadata from a run directory for archiving.
+
+    Args:
+        run_dir: Path to the run directory
+        daily_stats_dir: Optional path to daily stats directory for cost lookup
+
+    Returns:
+        Dictionary with run metadata suitable for archiving
+    """
+    run_id = run_dir.name
+    metadata: Dict[str, Any] = {
+        "run_id": run_id,
+        "workflow_name": "unknown",
+        "status": "UNKNOWN",
+        "created_at": utc_now(),
+        "ended_at": None,
+        "total_cost_usd": 0.0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "steps_completed": 0,
+        "steps_failed": 0,
+        "work_summary": "",
+    }
+
+    # Read run_state.json
+    state_file = run_dir / "run_state.json"
+    if state_file.exists():
+        try:
+            with state_file.open("r", encoding="utf-8") as f:
+                state_data = json.load(f)
+
+            metadata["workflow_name"] = state_data.get("workflow_name", "unknown")
+            metadata["created_at"] = state_data.get("created_at", metadata["created_at"])
+            metadata["ended_at"] = state_data.get("updated_at")
+
+            # Count steps and determine status
+            steps = state_data.get("steps", {})
+            completed_steps = []
+            failed_steps = []
+
+            for step_id, step_runtime in steps.items():
+                step_status = step_runtime.get("status", "")
+                if step_status == "COMPLETED":
+                    metadata["steps_completed"] += 1
+                    completed_steps.append(step_id)
+                elif step_status == "FAILED":
+                    metadata["steps_failed"] += 1
+                    failed_steps.append(step_id)
+
+                # Aggregate metrics if available
+                metrics = step_runtime.get("metrics", {})
+                if metrics:
+                    metadata["total_input_tokens"] += metrics.get("input_tokens", 0)
+                    metadata["total_output_tokens"] += metrics.get("output_tokens", 0)
+                    metadata["total_cost_usd"] += metrics.get("cost_usd", 0.0)
+
+            # Determine overall status
+            if metadata["steps_failed"] > 0:
+                metadata["status"] = "FAILED"
+            elif metadata["steps_completed"] > 0:
+                metadata["status"] = "COMPLETED"
+            else:
+                metadata["status"] = "UNKNOWN"
+
+            # Generate work summary
+            summary_parts = []
+            if completed_steps:
+                summary_parts.append(f"Completed: {', '.join(completed_steps[:5])}")
+                if len(completed_steps) > 5:
+                    summary_parts[-1] += f" (+{len(completed_steps) - 5} more)"
+            if failed_steps:
+                summary_parts.append(f"Failed: {', '.join(failed_steps[:3])}")
+            metadata["work_summary"] = "; ".join(summary_parts)
+
+        except (json.JSONDecodeError, OSError) as e:
+            _LOG.warning("Failed to parse run state at %s: %s", state_file, e)
+
+    # Try to get cost from daily stats if not in run_state
+    if daily_stats_dir and metadata["total_cost_usd"] == 0:
+        # Look for run in daily stats files
+        try:
+            for stats_file in sorted(daily_stats_dir.glob("*.json"), reverse=True):
+                try:
+                    with stats_file.open("r", encoding="utf-8") as f:
+                        stats_data = json.load(f)
+                    runs = stats_data.get("runs", {})
+                    if run_id in runs:
+                        run_info = runs[run_id]
+                        metadata["total_cost_usd"] = run_info.get("total_cost_usd", 0.0)
+                        # Also get step counts if we don't have them
+                        if metadata["steps_completed"] == 0:
+                            metadata["steps_completed"] = run_info.get("steps_completed", 0)
+                        if metadata["steps_failed"] == 0:
+                            metadata["steps_failed"] = run_info.get("steps_failed", 0)
+                        break
+                except (json.JSONDecodeError, OSError):
+                    continue
+        except OSError:
+            pass
+
+    return metadata

--- a/src/agent_orchestrator/web/templates/dashboard.html
+++ b/src/agent_orchestrator/web/templates/dashboard.html
@@ -145,4 +145,35 @@
         </div>
     </div>
 </div>
+
+<!-- All-time totals (including archived) -->
+{% if archive_stats and archive_stats.total_runs > 0 %}
+<div class="card" style="margin-top: 24px;">
+    <div class="card-header">
+        <h2 class="card-title">All-Time Totals (Archived Runs)</h2>
+    </div>
+    <div class="stats-grid" style="margin-bottom: 0;">
+        <div class="stat-card" style="background: transparent; border: none; padding: 0;">
+            <div class="stat-value" style="font-size: 24px; color: var(--text-secondary);">{{ archive_stats.total_runs }}</div>
+            <div class="stat-label">Archived Runs</div>
+        </div>
+        <div class="stat-card" style="background: transparent; border: none; padding: 0;">
+            <div class="stat-value" style="font-size: 24px; color: var(--accent-yellow);">{{ archive_stats.total_cost_usd|format_cost }}</div>
+            <div class="stat-label">Archived Cost</div>
+        </div>
+        <div class="stat-card" style="background: transparent; border: none; padding: 0;">
+            <div class="stat-value" style="font-size: 24px; color: var(--accent-blue);">{{ (archive_stats.total_input_tokens + archive_stats.total_output_tokens)|format_tokens }}</div>
+            <div class="stat-label">Archived Tokens</div>
+        </div>
+        <div class="stat-card" style="background: transparent; border: none; padding: 0;">
+            <div class="stat-value" style="font-size: 24px; color: var(--text-muted);">{{ archive_stats.total_steps_completed + archive_stats.total_steps_failed }}</div>
+            <div class="stat-label">Archived Steps</div>
+        </div>
+    </div>
+    <p style="color: var(--text-muted); font-size: 13px; margin-top: 12px; text-align: center;">
+        These runs have been cleaned up but their metadata is preserved.
+        <a href="/runs?source=archived" style="color: var(--accent-blue);">View archived runs</a>
+    </p>
+</div>
+{% endif %}
 {% endblock %}

--- a/src/agent_orchestrator/web/templates/run_detail.html
+++ b/src/agent_orchestrator/web/templates/run_detail.html
@@ -7,6 +7,9 @@
             <h1 class="page-title">
                 <a href="/runs" style="color: var(--text-secondary);">Runs</a> /
                 <span class="run-id">{{ run_id[:8] }}</span>
+                {% if is_archived %}
+                <span style="font-size: 14px; color: var(--text-muted); margin-left: 8px;" title="Archived run">&#128230; Archived</span>
+                {% endif %}
             </h1>
             <p class="page-subtitle">
                 {{ run_info.workflow_name }} -
@@ -55,10 +58,12 @@
                 <td style="color: var(--text-secondary); border: none;">Workflow</td>
                 <td style="border: none;">{{ run_info.workflow_name }}</td>
             </tr>
+            {% if not is_archived %}
             <tr>
                 <td style="color: var(--text-secondary); border: none;">Date</td>
                 <td style="border: none;">{{ run_info.date }}</td>
             </tr>
+            {% endif %}
             <tr>
                 <td style="color: var(--text-secondary); border: none;">Started</td>
                 <td style="border: none;">{{ run_info.started_at if run_info.started_at else '-' }}</td>
@@ -67,6 +72,18 @@
                 <td style="color: var(--text-secondary); border: none;">Ended</td>
                 <td style="border: none;">{{ run_info.ended_at if run_info.ended_at else '-' }}</td>
             </tr>
+            {% if is_archived %}
+            <tr>
+                <td style="color: var(--text-secondary); border: none;">Archived</td>
+                <td style="border: none; color: var(--text-muted);">{{ run_info.archived_at[:16] if run_info.archived_at else '-' }}</td>
+            </tr>
+            {% if run_info.work_summary %}
+            <tr>
+                <td style="color: var(--text-secondary); border: none;">Summary</td>
+                <td style="border: none;">{{ run_info.work_summary }}</td>
+            </tr>
+            {% endif %}
+            {% endif %}
         </table>
     </div>
 
@@ -91,6 +108,22 @@
                 <td style="border: none;">{{ total_duration|format_duration }}</td>
             </tr>
         </table>
+        {% elif is_archived %}
+        <table style="border: none;">
+            <tr>
+                <td style="color: var(--text-secondary); width: 120px; border: none;">Total Steps</td>
+                <td style="border: none;">{{ run_info.steps_completed + run_info.steps_failed }}</td>
+            </tr>
+            {% if run_info.total_input_tokens or run_info.total_output_tokens %}
+            <tr>
+                <td style="color: var(--text-secondary); border: none;">Total Tokens</td>
+                <td style="border: none;">{{ (run_info.total_input_tokens + run_info.total_output_tokens)|format_tokens }}</td>
+            </tr>
+            {% endif %}
+        </table>
+        <p style="color: var(--text-muted); font-size: 12px; margin-top: 8px;">
+            Detailed step data not available for archived runs.
+        </p>
         {% else %}
         <p style="color: var(--text-secondary);">No step details available</p>
         {% endif %}
@@ -124,6 +157,14 @@
             </div>
         </div>
         {% endfor %}
+    </div>
+    {% elif is_archived %}
+    <div class="empty-state">
+        <div class="empty-state-icon">&#128230;</div>
+        <p>This run has been archived. Detailed step data is no longer available.</p>
+        {% if run_info.work_summary %}
+        <p style="color: var(--text-secondary); margin-top: 8px;">{{ run_info.work_summary }}</p>
+        {% endif %}
     </div>
     {% else %}
     <div class="empty-state">

--- a/src/agent_orchestrator/web/templates/runs.html
+++ b/src/agent_orchestrator/web/templates/runs.html
@@ -2,18 +2,42 @@
 
 {% block content %}
 <div class="page-header">
-    <div style="display: flex; justify-content: space-between; align-items: center;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px;">
         <div>
             <h1 class="page-title">Run Explorer</h1>
             <p class="page-subtitle">Browse and search all workflow runs</p>
         </div>
-        <div class="time-range">
-            <a href="/runs?days=7" class="{{ 'active' if selected_days == 7 else '' }}">7 days</a>
-            <a href="/runs?days=14" class="{{ 'active' if selected_days == 14 else '' }}">14 days</a>
-            <a href="/runs?days=30" class="{{ 'active' if selected_days == 30 else '' }}">30 days</a>
+        <div style="display: flex; gap: 16px; align-items: center;">
+            <div class="time-range">
+                <a href="/runs?days=7&source={{ selected_source }}" class="{{ 'active' if selected_days == 7 else '' }}">7 days</a>
+                <a href="/runs?days=14&source={{ selected_source }}" class="{{ 'active' if selected_days == 14 else '' }}">14 days</a>
+                <a href="/runs?days=30&source={{ selected_source }}" class="{{ 'active' if selected_days == 30 else '' }}">30 days</a>
+            </div>
+            <div class="time-range">
+                <a href="/runs?days={{ selected_days }}&source=all" class="{{ 'active' if selected_source == 'all' else '' }}">All</a>
+                <a href="/runs?days={{ selected_days }}&source=live" class="{{ 'active' if selected_source == 'live' else '' }}">Live</a>
+                <a href="/runs?days={{ selected_days }}&source=archived" class="{{ 'active' if selected_source == 'archived' else '' }}">Archived</a>
+            </div>
         </div>
     </div>
 </div>
+
+{% if archive_stats and archive_stats.total_runs > 0 and selected_source in ['all', 'archived'] %}
+<div class="stats-grid" style="margin-bottom: 16px;">
+    <div class="stat-card" style="padding: 12px;">
+        <div class="stat-value" style="font-size: 20px;">{{ archive_stats.total_runs }}</div>
+        <div class="stat-label" style="font-size: 11px;">Archived Runs</div>
+    </div>
+    <div class="stat-card" style="padding: 12px;">
+        <div class="stat-value cost" style="font-size: 20px;">{{ archive_stats.total_cost_usd|format_cost }}</div>
+        <div class="stat-label" style="font-size: 11px;">Archived Cost</div>
+    </div>
+    <div class="stat-card" style="padding: 12px;">
+        <div class="stat-value" style="font-size: 20px;">{{ (archive_stats.total_input_tokens + archive_stats.total_output_tokens)|format_tokens }}</div>
+        <div class="stat-label" style="font-size: 11px;">Archived Tokens</div>
+    </div>
+</div>
+{% endif %}
 
 <div class="card">
     {% if runs %}
@@ -32,9 +56,12 @@
             </thead>
             <tbody>
                 {% for run in runs %}
-                <tr>
+                <tr style="{{ 'opacity: 0.7;' if run.source == 'archived' else '' }}">
                     <td>
                         <a href="/runs/{{ run.run_id }}" class="run-id">{{ run.run_id[:8] }}</a>
+                        {% if run.source == 'archived' %}
+                        <span style="font-size: 10px; color: var(--text-muted); margin-left: 4px;" title="Archived run - original files cleaned up">&#128230;</span>
+                        {% endif %}
                     </td>
                     <td style="color: var(--text-secondary);">{{ run.date }}</td>
                     <td>{{ run.workflow_name }}</td>
@@ -63,7 +90,13 @@
     {% else %}
     <div class="empty-state">
         <div class="empty-state-icon">&#x1F4AD;</div>
+        {% if selected_source == 'archived' %}
+        <p>No archived runs found</p>
+        {% elif selected_source == 'live' %}
+        <p>No live runs found in the last {{ selected_days }} days</p>
+        {% else %}
         <p>No runs found in the last {{ selected_days }} days</p>
+        {% endif %}
     </div>
     {% endif %}
 </div>


### PR DESCRIPTION
## Summary

Adds a lightweight SQLite database to preserve run metadata when runs are cleaned up by the retention policy. This addresses issue #42 by providing persistent historical tracking of costs, tokens, and run data.

- **New file**: `run_archive.py` - SQLite-based archive with automatic schema creation/migration
- **Modified**: `run_cleanup.py` - Archives run metadata before deletion
- **Modified**: `web/server.py` - Includes archived runs in API and UI
- **Updated**: Templates to show archived runs with distinct styling
- **Updated**: README with documentation

## Features

- Automatic database creation at `.agents/run_archive.db` (no setup required)
- Archives: run_id, workflow, status, costs, tokens, step counts, work summary
- Web dashboard shows "All-Time Totals (Archived Runs)" section
- Run Explorer has source filter (All / Live / Archived)
- Archived runs display with 📦 indicator
- New API endpoints: `/api/archive/stats`, `/api/archive/runs`

## Test plan

- [x] Verified archive DB is created automatically on first use
- [x] Verified runs are archived before cleanup deletion
- [x] Verified web dashboard shows archive stats
- [x] Verified Run Explorer filter works (all/live/archived)
- [x] Verified archived run detail page displays correctly
- [x] Verified API endpoints return correct data

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)